### PR TITLE
Inital I/O Example with Macros, Macro Corrections

### DIFF
--- a/mips/file-io-macros.asm
+++ b/mips/file-io-macros.asm
@@ -13,11 +13,11 @@
 .eqv	FILE_NULL_MODE	0
 
 # File Macros
-.macro file_open(%filename, %flags, %mode, %result_reg)
+.macro file_open(%filename, %flags, %result_reg)
 	li $v0, FILE_OPEN
 	move $a0, %filename
 	li $a1, %flags
-	li $a2, %mode
+	li $a2, FILE_NULL_MODE
 	syscall
 	move %result_reg, $v0
 .end_macro

--- a/mips/file-io-with-macros-example.asm
+++ b/mips/file-io-with-macros-example.asm
@@ -24,7 +24,7 @@ main:
 	la $t0, write_out_name  # load the filename pointer into a register
 	# Open the file with name in write_out_name
 	# Save descriptor value in $s0
-	file_open($t0, FILE_OPEN_WRITE, FILE_NULL_MODE, $s0)
+	file_open($t0, FILE_OPEN_WRITE, $s0)
 	
 	# Determine length of data to write in $t0
 	la $t0, write_out_data
@@ -47,7 +47,7 @@ main:
 	la $t0, read_in_name # load the filename pointer into a register
 	# Open the file with name in read_in_name
 	# Save descriptor value in $s0 
-	file_open($t0, FILE_OPEN_READ, FILE_NULL_MODE, $s0)
+	file_open($t0, FILE_OPEN_READ, $s0)
 	
 	# Read from file in $s0 into buff
 	# Save chars read in $s1


### PR DESCRIPTION
Created an initial file I/O example that uses the macros.
Fixed the macros to operate correctly for this example. Reading requires a constant max reading length and writing requires a register containing the write length. Corrected the syscall values for file read/write, which were swapped.

All four file operation macros were used for valid operations here. The util macros were also utilized in this example.
